### PR TITLE
implemented service for translations

### DIFF
--- a/reactClient/src/QuestionEditorPage/QuestionEditorPage.jsx
+++ b/reactClient/src/QuestionEditorPage/QuestionEditorPage.jsx
@@ -230,7 +230,7 @@ class QuestionEditorPage extends React.Component {
                                     displayEmpty
                                 >
                                     <MenuItem value="" disabled>
-                                        Select Question Type
+                                        Select translation language
                                     </MenuItem>
                                     {newAccessibleLanguages.map(l =>
                                         <MenuItem key={l.name} value={l.name}>{l.name}</MenuItem>

--- a/reactClient/src/TestPage/TestPage.jsx
+++ b/reactClient/src/TestPage/TestPage.jsx
@@ -34,7 +34,7 @@ class TestPage extends React.Component {
             questionAnswers.push({questionName: q.name, content: ''})
         });
         const testResolution = {
-            testName: test.name,
+            testName: test.testName,
             username: user.username,
             questionAnswers
         };

--- a/reactClient/src/_services/index.js
+++ b/reactClient/src/_services/index.js
@@ -5,3 +5,4 @@ export * from './test.service';
 export * from './editor.service';
 export * from './question.service';
 export * from './menu.service';
+export * from './language.service';

--- a/reactClient/src/_services/test.service.js
+++ b/reactClient/src/_services/test.service.js
@@ -10,7 +10,7 @@ export const testService = {
     updatePosition,
     addQuestion,
     deleteQuestion,
-    updateName
+    translate
 };
 
 function getAll(positionName) {
@@ -64,19 +64,6 @@ function deleteQuestion(testName, questionName){
     .then(handleResponse);
 }
 
-function updateName(oldName,testObj){
-    const requestOptions = {
-        method: 'PUT',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': localStorage.getItem('Token')
-        },
-        body: JSON.stringify(testObj)
-    };
-    return fetch(`${config.apiUrl}/test/updateName/${oldName}`, requestOptions)
-    .then(handleResponse);
-}
-
 function updatePosition(testObj){
     const requestOptions = {
         method: 'PUT',
@@ -88,4 +75,10 @@ function updatePosition(testObj){
     };
     return fetch(`${config.apiUrl}/test/updatePosition`, requestOptions)
     .then(handleResponse);
+}
+
+function translate(testName, targetLanguage) {
+    const requestOptions = { method: 'PUT', headers: authHeader() };
+    return fetch(`${config.apiUrl}/test/translate/${testName}/${targetLanguage}`, requestOptions)
+        .then(handleResponse);
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compile"org.springframework.boot:spring-boot-starter-security"
 	compile"io.jsonwebtoken:jjwt:0.7.0"
 	compile('com.google.code.gson:gson:2.8.2')
+	compile 'com.google.cloud:google-cloud-translate:1.74.0'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly("org.projectlombok:lombok:1.16.18")

--- a/server/src/main/java/pl/masi/controllers/TestController.java
+++ b/server/src/main/java/pl/masi/controllers/TestController.java
@@ -65,14 +65,14 @@ public class TestController {
         testService.updatePosition(testBean);
     }
 
-    @PutMapping(value = "/updateName/{oldName}")
-    public void updateName(@PathVariable String oldName, @RequestBody TestBean testBean) throws AppException {
-        testService.updateName(oldName, testBean);
-    }
-
     @DeleteMapping(value = "/{testName}/{questionName}")
     public void deleteQuestion(@PathVariable String testName, @PathVariable String questionName) throws AppException {
         testService.deleteQuestion(testName, questionName);
+    }
+
+    @PutMapping(value= "/translate/{testName}/{targetLanguage}")
+    public void translateTest(@PathVariable String testName, @PathVariable String targetLanguage) throws AppException {
+        testService.translateTest(testName, targetLanguage);
     }
 
     @ExceptionHandler({AppException.class})

--- a/server/src/main/java/pl/masi/services/implementations/TranslationService.java
+++ b/server/src/main/java/pl/masi/services/implementations/TranslationService.java
@@ -1,0 +1,25 @@
+package pl.masi.services.implementations;
+
+import com.google.cloud.translate.Detection;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+import pl.masi.services.interfaces.ITranslationService;
+
+public class TranslationService implements ITranslationService {
+
+    private Translate translate;
+
+    public TranslationService() {
+        translate = TranslateOptions.getDefaultInstance().getService();
+    }
+
+    @Override
+    public String translateText(String text, String targetLanguage) {
+        Translation translation = translate.translate(
+                        text,
+                        Translate.TranslateOption.targetLanguage(targetLanguage));
+
+        return translation.getTranslatedText();
+    }
+}

--- a/server/src/main/java/pl/masi/services/interfaces/ITestService.java
+++ b/server/src/main/java/pl/masi/services/interfaces/ITestService.java
@@ -23,7 +23,7 @@ public interface ITestService {
 
     void updatePosition(TestBean testBean) throws AppException;
 
-    void updateName(String oldName, TestBean testBean) throws AppException;
-
     void deleteQuestion(String testName, String questionName) throws AppException;
+
+    void translateTest(String testName, String targetLanguage) throws AppException;
 }

--- a/server/src/main/java/pl/masi/services/interfaces/ITranslationService.java
+++ b/server/src/main/java/pl/masi/services/interfaces/ITranslationService.java
@@ -1,0 +1,5 @@
+package pl.masi.services.interfaces;
+
+public interface ITranslationService {
+    public String translateText(String text, String targetLanguage);
+}

--- a/server/src/main/resources/google-key.json
+++ b/server/src/main/resources/google-key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "my-project-1521545378891",
+  "private_key_id": "c09dd8a4c83b888245c750da70a591fb53dc4aa6",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNT6n3hP6nh1x6\nm8fSjGOjYmrCviwJnTKmNbsN3eeKNsdeaIgzMD24md7pVrzGxa3kUd4is7qhZiXm\nfp1ncywEuxeF482lAPZPtGuZO29fVBin26FNxnoPt/jnJ1wVCIscHUvG8pbu9trc\nEhH0P/VK5jQ86Uex77NHHLv/wxeWTxVgJpOqhNVJkxZ/IZGxOj/I/uFU7xY+i7AQ\nuRkScKzJj9wuM5oYtBtBpqbpnSXnIfsS5wYIpN19J33O0BmmR19qPejfiDlEhF+G\nSOh12czo1Dj6fRVMyXw5xZRDd3hlGw5h/tN2Vph3CEKJZX4OW9TlWJrErxribx3A\n3156PqlfAgMBAAECggEACYy3Ytb3Iq24zyR90pJLHtIOFd7TR43d9D3djyiPg4NG\nxLe8q2eGshZzeDZbniybCQVcfWVkvJXMFNY2K2tU/ydV/G6l0Giktv0KYDHpMphD\nyVL9mWjY9prfuJ4WZLgQAw/DHY7dFw0OYwbIJQHwk+T0mxIIDq5lOrKLIBC1Vn1j\n3Z7x6nbA03uUX9TfgvNISDRSm+psbVOFFeeFVphZtBj7hxJLXhQ/uFMjQX/pVug0\ndsQeI6t7f3S3RMcEjmER90bFzFRoKXFApNWUbTGAtVHHFi3SGv2khcutFSgZOiBy\nKHN3Nu4EiKedZ7zKBCiafP0HEH6/rxOfmuYpH4LZyQKBgQDrl73HobDG2BO/lov/\nYP4PHQzenRy7Jev7pGz6w/hBUDORpvgOjuvlk3IrzsLzw9Za/GsZDbwXwVoicaQF\nmFLe+lDqbGrtoAb1q8kIGNzbHnxLcWVaubLmbn4yyDBHmHhCMbviCcrk0Z8IKUzI\nRJ7UFlrk3DIganq793xY6ku86wKBgQDfGG417WUClRItVO0UBZgLihtCuBIm7/tZ\nRM28UdsSVVTSAxABo5/N1SfkHFmUWqYRqN5xS4GTEhaG4Vxzc2gdFl5jm/7hnbVr\nzkaNTDnWptXAlOnoXBMDzKlsjZIRn62NGZclvRA2NQFBX0S1X13+vkqo/L4+erM9\nb2+BQ88YXQKBgQCR1JjV1MFvJFt9EXxRNUGuK0ZHGiupsLyVRN9sjhfCnhl9xEPy\nBwgAULewZEkKySOLqInGtVjDv5zCi2ODTxmlCn9BzKCXvKHyOkazK2iyfflkXanm\nceJKfwTA/GfeOYPfPZfWQEeGQjdVvvLXWJqUH85dseuZYy/b4ELpawY8xwKBgQCo\nwktEQeLB9E/+uJpqJd0hBYSfkKwyhiCFI5XZmbX1BVWXU7e89bBBvLdjR8q/fV7Y\nRvyViT9oKCugNkOAFdGxByW5hdxlgK4m8a/O3NV3uVZCSqMyIMxFeIDE28adzEM1\nVCFQ69aimq/raoyIAq8Qr5O8hwvGKX0CwRQBHXFABQKBgQCu9pbIDXvbr4dtJ436\nMm5qHpyyJ5q2NyIxn47yWnDiVFwTPLxF/eeQKQz1ul0Llgrj9VTtjm5CI34M/UJs\ncLlg+HmBwdv8V90qSsIBmRjSrwDxbqDZ0p4JLd7cZaK91rkNLVVd15H1GyQCDmcm\nrckgBcmNysZ6QCotFc2OhwFxgw==\n-----END PRIVATE KEY-----\n",
+  "client_email": "starting-account-3pchk9aertq0@my-project-1521545378891.iam.gserviceaccount.com",
+  "client_id": "117506365808295097318",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/starting-account-3pchk9aertq0%40my-project-1521545378891.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Dear colleagues,

Google cloud translation api wants the clients to set the security.json to theirs environment paths.
Because of that I added the given .json to our project.
In your intellij settings please add 
GOOGLE_APPLICATION_CREDENTIALS:path_to_added.json
in the environment path section.
Unfortunately, this json key have to be set by the environment path or by the deprecated method.
@G-Jasnowski You can start implementation of csv export/import. I think, the interface will not change much, even if we will change the api provider.
The targetLanguage argument in the translateText method should be passed in the following notation:
"pl" for Polish translations,
"en" for english translations and so on.